### PR TITLE
Adjust default behaviour for PUT to be closer to DDB behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ await table
     - [Comparison Operators](#comparison-operators)
     - [Logical Operators](#logical-operators)
     - [Query Operations](#query-operations)
+    - [Put Operations](#put-operations)
     - [Update Operations](#update-operations)
       - [Condition Operators](#condition-operators)
       - [Multiple Operations](#multiple-operations)
@@ -445,6 +446,51 @@ const limited = await table
   .query({ pk: "USER#123" })
   .limit(10)
   .execute();
+```
+
+### Put Operations
+
+| Operation           | Method Example                                                      | Description                                                            |
+|---------------------|---------------------------------------------------------------------|------------------------------------------------------------------------|
+| **Create New Item** | `.create<Dinosaur>({ pk: "SPECIES#trex", sk: "PROFILE#001", ... })` | Creates a new item with a condition to ensure it doesn't already exist |
+| **Put Item**        | `.put<Dinosaur>({ pk: "SPECIES#trex", sk: "PROFILE#001", ... })`    | Creates or replaces an item                                            |
+| **With Condition**  | `.put(item).condition(op => op.attributeNotExists("pk"))`           | Adds a condition that must be satisfied                                |
+
+#### Return Values
+
+Control what data is returned from put operations:
+
+| Option         | Description                                                                                                        | Example                                           |
+|----------------|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
+| **NONE**       | Default. No return value.                                                                                          | `.put(item).returnValues("NONE").execute()`       |
+| **ALL_OLD**    | Returns the item's previous state if it existed. (Does not consume any RCU and returns strongly consistent values) | `.put(item).returnValues("ALL_OLD").execute()`    |
+| **CONSISTENT** | Performs a consistent GET operation after the put to retrieve the item's new state. (Does consume RCU)             | `.put(item).returnValues("CONSISTENT").execute()` |
+
+```ts
+// Create with no return value (default)
+await table.put<Dinosaur>({
+  pk: "SPECIES#trex",
+  sk: "PROFILE#001",
+  name: "Tyrannosaurus Rex",
+  diet: "carnivore"
+}).execute();
+
+// Create and return the newly created item
+const newDino = await table.put<Dinosaur>({
+  pk: "SPECIES#trex",
+  sk: "PROFILE#002",
+  name: "Tyrannosaurus Rex",
+  diet: "carnivore"
+}).returnValues("CONSISTENT").execute();
+
+// Update with condition and get previous values
+const oldDino = await table.put<Dinosaur>({
+  pk: "SPECIES#trex",
+  sk: "PROFILE#001",
+  name: "Tyrannosaurus Rex",
+  diet: "omnivore", // Updated diet
+  discoveryYear: 1905
+}).returnValues("ALL_OLD").execute();
 ```
 
 ### Update Operations

--- a/examples/gsi-example.ts
+++ b/examples/gsi-example.ts
@@ -200,7 +200,9 @@ async function createDinosaur(
     updatedAt: now,
   } as Dinosaur;
 
-  return await dinoTable.put(dinosaur).execute();
+  await dinoTable.put(dinosaur).execute();
+
+  return dinosaur;
 }
 
 async function createFossil(
@@ -217,7 +219,13 @@ async function createFossil(
     updatedAt: now,
   } as Fossil;
 
-  return await dinoTable.put(newFossil).execute();
+  const fossil = await dinoTable.put(newFossil).returnValues("CONSISTENT").execute();
+
+  if (!fossil) {
+    throw new Error("Fossil not created");
+  }
+
+  return fossil;
 }
 
 async function updateDinosaurHabitat(dinoId: string, habitatId: string): Promise<void> {

--- a/src/__tests__/table-create.itest.ts
+++ b/src/__tests__/table-create.itest.ts
@@ -21,8 +21,7 @@ describe("Table Integration Tests - Create Items", () => {
       period: "Late Cretaceous",
     };
 
-    const result = await table.create(dino).execute();
-    expect(result).toEqual(dino);
+    await table.create(dino).execute();
 
     // Verify item was created
     const queryResult = await table.query({ pk: "dinosaur#1" }).execute();

--- a/src/__tests__/table-put.itest.ts
+++ b/src/__tests__/table-put.itest.ts
@@ -18,7 +18,7 @@ describe("Table Integration Tests - Put Items", () => {
       period: "Late Jurassic",
     };
 
-    const result = await table.put(dino).execute();
+    const result = await table.put(dino).returnValues("CONSISTENT").execute();
     expect(result).toEqual(dino);
 
     // Verify item was created
@@ -47,6 +47,7 @@ describe("Table Integration Tests - Put Items", () => {
     const result = await table
       .put(updatedDino)
       .condition((op) => op.eq("name", "Brachiosaurus"))
+      .returnValues("CONSISTENT")
       .execute();
 
     expect(result).toEqual(updatedDino);
@@ -88,8 +89,9 @@ describe("Table Integration Tests - Put Items", () => {
       },
     };
 
+    // Not set the return values too CONSISTENT to ensure the undefined value is retained
     const result = await table.put(dino).execute();
-    expect(result).toEqual(dino);
+    expect(result).toEqual(undefined);
 
     // Verify item was created and undefined keys are retained as `undefined` in the stored object
     const getResult = await table.get<Dinosaur>({ pk: "dinosaur#6", sk: "dino#spino" }).execute();
@@ -112,7 +114,7 @@ describe("Table Integration Tests - Put Items", () => {
       },
     };
 
-    const result = await table.put(dino).execute();
+    const result = await table.put(dino).returnValues("CONSISTENT").execute();
     expect(result).toEqual(dino);
 
     // Verify item was created and empty string keys are retained in the stored object

--- a/src/builders/__tests__/put-builder.test.ts
+++ b/src/builders/__tests__/put-builder.test.ts
@@ -81,7 +81,7 @@ describe("PutBuilder", () => {
         conditionExpression: expect.any(String),
         expressionAttributeNames: expect.any(Object),
         expressionAttributeValues: expect.any(Object),
-        returnValues: "RETURN_AFTER_PUT",
+        returnValues: "NONE",
       });
       expect(result).toBe(mockResponse);
     });
@@ -97,7 +97,7 @@ describe("PutBuilder", () => {
       expect(mockExecutor).toHaveBeenCalledWith({
         tableName,
         item,
-        returnValues: "RETURN_AFTER_PUT",
+        returnValues: "NONE",
       });
       expect(result).toBe(mockResponse);
     });
@@ -133,7 +133,7 @@ describe("PutBuilder", () => {
           conditionExpression: "#0 = :0",
           expressionAttributeNames: { "#0": "status" },
           expressionAttributeValues: { ":0": "active" },
-          returnValues: "RETURN_AFTER_PUT",
+          returnValues: "NONE",
         },
         readable: {
           conditionExpression: 'status = "active"',
@@ -149,7 +149,21 @@ describe("PutBuilder", () => {
         raw: {
           tableName,
           item,
-          returnValues: "RETURN_AFTER_PUT",
+          returnValues: "NONE",
+        },
+        readable: {},
+      });
+    });
+
+    it("should correctly debug withReturn value being set", () => {
+      const builder = new PutBuilder<TestItem>(mockExecutor, item, tableName).returnValues("CONSISTENT");
+      const debug = builder.debug();
+
+      expect(debug).toEqual({
+        raw: {
+          tableName,
+          item,
+          returnValues: "CONSISTENT",
         },
         readable: {},
       });

--- a/src/builders/builder-types.ts
+++ b/src/builders/builder-types.ts
@@ -19,7 +19,7 @@ export interface DeleteCommandParams extends DynamoCommandWithExpressions {
  * The `returnValues` property can be:
  * - `"ALL_OLD"`: Return the attributes of the item as they were before the operation
  * - `"NONE"`: Return nothing
- * - `"RETURN_AFTER_PUT"`: Triggers a GET operation after the put to retrieve the updated item state
+ * - `"CONSISTENT"`: Triggers a GET operation after the put to retrieve the updated item state
  */
 export interface PutCommandParams extends DynamoCommandWithExpressions {
   tableName: string;
@@ -27,7 +27,7 @@ export interface PutCommandParams extends DynamoCommandWithExpressions {
   conditionExpression?: string;
   expressionAttributeNames?: Record<string, string>;
   expressionAttributeValues?: Record<string, unknown>;
-  returnValues?: "ALL_OLD" | "NONE" | "RETURN_AFTER_PUT";
+  returnValues?: "ALL_OLD" | "NONE" | "CONSISTENT";
 }
 
 /**

--- a/src/table.ts
+++ b/src/table.ts
@@ -113,13 +113,13 @@ export class Table<TConfig extends TableConfig = TableConfig> {
           ConditionExpression: params.conditionExpression,
           ExpressionAttributeNames: params.expressionAttributeNames,
           ExpressionAttributeValues: params.expressionAttributeValues,
-          // RETURN_AFTER_PUT is not a valid ReturnValue for DDB, so we set NONE as we are not interested in its
+          // CONSISTENT is not a valid ReturnValue for DDB, so we set NONE as we are not interested in its
           // response and will be reloading the item from the DB through a get instead
-          ReturnValues: params.returnValues === "RETURN_AFTER_PUT" ? "NONE" : params.returnValues,
+          ReturnValues: params.returnValues === "CONSISTENT" ? "NONE" : params.returnValues,
         });
 
         // Reload the item from the DB, so the user gets the most correct representation of the item from the DB
-        if (params.returnValues === "RETURN_AFTER_PUT") {
+        if (params.returnValues === "CONSISTENT") {
           const key = {
             pk: params.item[this.partitionKey],
             ...(this.sortKey && { sk: params.item[this.sortKey] }),


### PR DESCRIPTION
Update returnValues to default to none instead of RETURN_AFTER_PUT. Developers can use CONSISTENT if they want the modified record back from the DB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded documentation with a new "Put Operations" section covering `.put()`, `.create()`, conditional expressions, and return value options.
  - Updated code examples and Table of Contents accordingly.

- **Bug Fixes**
  - Improved handling of put operation return value options to ensure consistent and accurate results.

- **Tests**
  - Revised and added tests to reflect updated default and explicit return value behaviors for put operations.

- **Refactor**
  - Renamed return value option from "RETURN_AFTER_PUT" to "CONSISTENT" for clarity.
  - Updated method signatures and return types to align with new put operation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->