### PR TITLE
feat(builder)!: add support for `INPUT` return value in put operations

### DIFF
--- a/src/__tests__/table-create.itest.ts
+++ b/src/__tests__/table-create.itest.ts
@@ -9,7 +9,7 @@ describe("Table Integration Tests - Create Items", () => {
     table = createTestTable();
   });
 
-  it("should create a new item", async () => {
+  it("should create a new item and return input values by default", async () => {
     const dino: Dinosaur = {
       demoPartitionKey: "dinosaur#1",
       demoSortKey: "dino#trex",
@@ -21,10 +21,35 @@ describe("Table Integration Tests - Create Items", () => {
       period: "Late Cretaceous",
     };
 
-    await table.create(dino).execute();
+    const result = await table.create(dino).execute();
 
-    // Verify item was created
+    // Verify that create returns the input values by default
+    expect(result).toEqual(dino);
+
+    // Verify item was created in the database
     const queryResult = await table.query({ pk: "dinosaur#1" }).execute();
+    expect(queryResult.items).toHaveLength(1);
+    expect(queryResult.items[0]).toEqual(dino);
+  });
+
+  it("should allow customizing return values through returnValues method", async () => {
+    const dino: Dinosaur = {
+      demoPartitionKey: "dinosaur#3",
+      demoSortKey: "dino#stego",
+      name: "Stegosaurus",
+      type: "Stegosaurid",
+      height: 9,
+      weight: 5000,
+      diet: "Herbivore",
+      period: "Late Jurassic",
+    };
+
+    // Test with NONE return value
+    const noneResult = await table.create(dino).returnValues("NONE").execute();
+    expect(noneResult).toBeUndefined();
+
+    // Verify item was still created
+    const queryResult = await table.query({ pk: "dinosaur#3" }).execute();
     expect(queryResult.items).toHaveLength(1);
     expect(queryResult.items[0]).toEqual(dino);
   });

--- a/src/builders/builder-types.ts
+++ b/src/builders/builder-types.ts
@@ -20,6 +20,7 @@ export interface DeleteCommandParams extends DynamoCommandWithExpressions {
  * - `"ALL_OLD"`: Return the attributes of the item as they were before the operation
  * - `"NONE"`: Return nothing
  * - `"CONSISTENT"`: Triggers a GET operation after the put to retrieve the updated item state
+ * - `"INPUT"`: Return the input values that were passed to the operation (useful for create operations)
  */
 export interface PutCommandParams extends DynamoCommandWithExpressions {
   tableName: string;
@@ -27,7 +28,7 @@ export interface PutCommandParams extends DynamoCommandWithExpressions {
   conditionExpression?: string;
   expressionAttributeNames?: Record<string, string>;
   expressionAttributeValues?: Record<string, unknown>;
-  returnValues?: "ALL_OLD" | "NONE" | "CONSISTENT";
+  returnValues?: "ALL_OLD" | "NONE" | "CONSISTENT" | "INPUT";
 }
 
 /**

--- a/src/builders/put-builder.ts
+++ b/src/builders/put-builder.ts
@@ -32,9 +32,10 @@ export interface PutOptions {
    * @options
    *  - NONE: No return value
    *  - ALL_OLD: Returns the item's previous state if it existed
-   *  - CONSISTENT: (default) Performs a GET operation after the put to retrieve the item's new state
+   *  - CONSISTENT: Performs a GET operation after the put to retrieve the item's new state
+   *  - INPUT: Returns the input values that were passed to the operation
    */
-  returnValues?: "ALL_OLD" | "NONE" | "CONSISTENT";
+  returnValues?: "ALL_OLD" | "NONE" | "CONSISTENT" | "INPUT";
 }
 
 type PutExecutor<T extends DynamoItem> = (params: PutCommandParams) => Promise<T>;
@@ -216,7 +217,8 @@ export class PutBuilder<T extends DynamoItem> {
    * @options
    *  - NONE: No return value
    *  - ALL_OLD: Returns the item's previous state if it existed, no read capacity units are consumed
-   *  - CONSISTENT: (default) Performs a GET operation after the put to retrieve the item's new state
+   *  - CONSISTENT: Performs a GET operation after the put to retrieve the item's new state
+   *  - INPUT: Returns the input values that were passed to the operation
    *
    * @example
    * ```ts
@@ -235,12 +237,17 @@ export class PutBuilder<T extends DynamoItem> {
    *     }
    *   });
    * }
+   *
+   * // Return input values for create operations
+   * const createResult = await builder
+   *   .returnValues('INPUT')
+   *   .execute();
    * ```
    *
-   * @param returnValues - Use 'ALL_OLD' to return previous values if the item was overwritten, or 'NONE' (default).
+   * @param returnValues - Use 'ALL_OLD' to return previous values, 'INPUT' to return input values, 'CONSISTENT' for fresh data, or 'NONE' (default).
    * @returns The builder instance for method chaining
    */
-  public returnValues(returnValues: "ALL_OLD" | "NONE" | "CONSISTENT"): this {
+  public returnValues(returnValues: "ALL_OLD" | "NONE" | "CONSISTENT" | "INPUT"): this {
     this.options.returnValues = returnValues;
     return this;
   }


### PR DESCRIPTION
Add `INPUT` as a new return value option for put operations, allowing the input values to be returned directly. Update the `create` method to use `INPUT` as the default return value. Adjusted tests and documentation to reflect the new behavior and describe use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new return option, "INPUT", allowing create and put operations to return the input item directly.
  - Enhanced control over returned data after put operations, including options for fetching fresh data with consistent reads.

- **Documentation**
  - Expanded documentation with detailed examples for customizing return values in create and put operations.

- **Tests**
  - Added and updated tests to verify the new "INPUT" return value behavior and ensure correct operation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->