### PR TITLE
fix: Chained filter calls overwrote the previous filter

### DIFF
--- a/examples/entity-example/README.md
+++ b/examples/entity-example/README.md
@@ -9,6 +9,7 @@ This example implements a simple dinosaur management system using dyno-table wit
 - Entity definition with Zod schemas
 - Type-safe CRUD operations
 - Query and scan operations with filters
+- Filter chaining with AND logic
 - Data validation
 - Local DynamoDB integration
 

--- a/src/__tests__/entity-queries.test.ts
+++ b/src/__tests__/entity-queries.test.ts
@@ -826,7 +826,8 @@ describe("createQuery with chained filters", () => {
     schema: testSchema,
     primaryKey: createIndex()
       .input(primaryKeySchema)
-      .partitionKey((item) => `TEST#${item.id}`),
+      .partitionKey((item) => `TEST#${item.id}`)
+      .sortKey(() => "METADATA#"),
     queries: {
       byStatusAndType: createQueries<TestEntity>()
         .input(byStatusInputSchema)
@@ -933,7 +934,8 @@ describe("createQuery with chained filters", () => {
       schema: testSchema,
       primaryKey: createIndex()
         .input(primaryKeySchema)
-        .partitionKey((item) => `TEST#${item.id}`),
+        .partitionKey((item) => `TEST#${item.id}`)
+        .sortKey(() => "METADATA#"),
       queries: {
         byStatus: createQueries<TestEntity>()
           .input(byStatusInputSchema)
@@ -969,7 +971,8 @@ describe("createQuery with chained filters", () => {
       schema: testSchema,
       primaryKey: createIndex()
         .input(primaryKeySchema)
-        .partitionKey((item) => `TEST#${item.id}`),
+        .partitionKey((item) => `TEST#${item.id}`)
+        .sortKey(() => "METADATA#"),
       queries: {
         activeItems: createQueries<TestEntity>()
           .input(byStatusInputSchema)
@@ -1017,7 +1020,8 @@ describe("createQuery with chained filters", () => {
       schema: testSchema,
       primaryKey: createIndex()
         .input(primaryKeySchema)
-        .partitionKey((item) => `TEST#${item.id}`),
+        .partitionKey((item) => `TEST#${item.id}`)
+        .sortKey(() => "METADATA#"),
       queries: {
         itemsByStatus: createQueries<TestEntity>()
           .input(byStatusInputSchema)

--- a/src/__tests__/entity-queries.test.ts
+++ b/src/__tests__/entity-queries.test.ts
@@ -820,3 +820,244 @@ describe("Entity Repository - Deferred Validation", () => {
     expect(() => repository.create(testData).withTransaction({} as any)).toThrow("Validation failed");
   });
 });
+describe("createQuery with chained filters", () => {
+  const entityWithChainedFilters = defineEntity({
+    name: "TestEntity",
+    schema: testSchema,
+    primaryKey: createIndex()
+      .input(primaryKeySchema)
+      .partitionKey((item) => `TEST#${item.id}`),
+    queries: {
+      byStatusAndType: createQueries<TestEntity>()
+        .input(byStatusInputSchema)
+        .query(({ input, entity }) => {
+          return entity
+            .scan()
+            .filter(eq("status", input.status))
+            .filter(eq("type", "test"));
+        }),
+      byComplexFilters: createQueries<TestEntity>()
+        .input(byStatusInputSchema)
+        .query(({ input, entity }) => {
+          return entity
+            .scan()
+            .filter(eq("status", input.status))
+            .filter((op) => op.or(op.eq("type", "test"), op.eq("type", "test2")))
+            .filter((op) => op.gt("createdAt", "2023-01-01"));
+        }),
+      byQueryWithMultipleFilters: createQueries<TestEntity>()
+        .input(byStatusInputSchema)
+        .query(({ input, entity }) => {
+          return entity.query({
+            pk: `TEST#${input.id}`,
+            sk: (op) => op.beginsWith("METADATA#"),
+          })
+          .filter(eq("status", input.status))
+          .filter(eq("type", "test"));
+        }),
+    },
+  });
+
+  let repository: ReturnType<typeof entityWithChainedFilters.createRepository>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repository = entityWithChainedFilters.createRepository(
+      mockTable as unknown as Table
+    );
+  });
+
+  it("should chain filters with AND", async () => {
+    const mockBuilder = {
+      filter: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue({ items: [] }),
+    };
+
+    mockTable.scan.mockReturnValue(mockBuilder);
+
+    await repository.query
+      .byStatusAndType({ status: "active", id: "123", test: "test" })
+      .execute();
+
+    // Check that filters are applied in the correct order
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(1, eq("entityType", "TestEntity"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(2, eq("status", "active"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(3, eq("type", "test"));
+  });
+
+  it("should chain complex filters with AND/OR combinations", async () => {
+    const mockBuilder = {
+      filter: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue({ items: [] }),
+    };
+
+    mockTable.scan.mockReturnValue(mockBuilder);
+
+    await repository.query
+      .byComplexFilters({ status: "active", id: "123", test: "test" })
+      .execute();
+
+    // Check that filters are applied in the correct order
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(1, eq("entityType", "TestEntity"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(2, eq("status", "active"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(3, expect.any(Function)); // OR condition
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(4, expect.any(Function)); // GT condition
+  });
+
+  it("should chain filters on query builders", async () => {
+    const mockBuilder = {
+      filter: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue({ items: [] }),
+    };
+
+    mockTable.query.mockReturnValue(mockBuilder);
+
+    await repository.query
+      .byQueryWithMultipleFilters({ status: "active", id: "123", test: "test" })
+      .execute();
+
+    expect(mockTable.query).toHaveBeenCalledWith({
+      pk: "TEST#123",
+      sk: expect.any(Function),
+    });
+    
+    // For query builders, user filters are applied first, then entity type filter
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(1, eq("status", "active"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(2, eq("type", "test"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(3, eq("entityType", "TestEntity"));
+  });
+
+  it("should handle single filter correctly", async () => {
+    const entityWithSingleFilter = defineEntity({
+      name: "TestEntitySingle",
+      schema: testSchema,
+      primaryKey: createIndex()
+        .input(primaryKeySchema)
+        .partitionKey((item) => `TEST#${item.id}`),
+      queries: {
+        byStatus: createQueries<TestEntity>()
+          .input(byStatusInputSchema)
+          .query(({ input, entity }) => {
+            return entity.scan().filter(eq("status", input.status));
+          }),
+      },
+    });
+
+    const repo = entityWithSingleFilter.createRepository(
+      mockTable as unknown as Table
+    );
+
+    const mockBuilder = {
+      filter: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue({ items: [] }),
+    };
+
+    mockTable.scan.mockReturnValue(mockBuilder);
+
+    await repo.query
+      .byStatus({ status: "active", id: "123", test: "test" })
+      .execute();
+
+    // Check that filters are applied in the correct order
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(1, eq("entityType", "TestEntitySingle"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(2, eq("status", "active"));
+  });
+
+  it("should apply both createQuery filters and execution-time filters", async () => {
+    const entityWithPreAppliedFilters = defineEntity({
+      name: "TestEntityWithFilters",
+      schema: testSchema,
+      primaryKey: createIndex()
+        .input(primaryKeySchema)
+        .partitionKey((item) => `TEST#${item.id}`),
+      queries: {
+        activeItems: createQueries<TestEntity>()
+          .input(byStatusInputSchema)
+          .query(({ input, entity }) => {
+            // Apply a filter in the query definition
+            return entity
+              .scan()
+              .filter(eq("status", input.status)); // This is "active" from the input
+          }),
+      },
+    });
+
+    const repo = entityWithPreAppliedFilters.createRepository(
+      mockTable as unknown as Table
+    );
+
+    const mockBuilder = {
+      filter: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue({ items: [] }),
+    };
+
+    mockTable.scan.mockReturnValue(mockBuilder);
+
+    // Apply another filter when executing the query
+    await repo.query
+      .activeItems({ status: "active", id: "123", test: "test" })
+      .filter(eq("type", "test"))
+      .execute();
+
+    // Check that all filters are applied in the correct order:
+    // 1. Entity type filter (applied by scan())
+    // 2. Pre-applied filter from createQuery (status = "active")
+    // 3. Entity type filter (applied by query execution logic)
+    // 4. Execution-time filter (type = "test")
+    expect(mockBuilder.filter).toHaveBeenCalledTimes(4);
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(1, eq("entityType", "TestEntityWithFilters"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(2, eq("status", "active"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(3, eq("entityType", "TestEntityWithFilters"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(4, eq("type", "test"));
+  });
+
+  it("should apply both createQuery filters and execution-time filters on query builders", async () => {
+    const entityWithPreAppliedQueryFilters = defineEntity({
+      name: "TestEntityWithQueryFilters",
+      schema: testSchema,
+      primaryKey: createIndex()
+        .input(primaryKeySchema)
+        .partitionKey((item) => `TEST#${item.id}`),
+      queries: {
+        itemsByStatus: createQueries<TestEntity>()
+          .input(byStatusInputSchema)
+          .query(({ input, entity }) => {
+            // Apply a filter in the query definition
+            return entity
+              .query({ pk: `TEST#${input.id}` })
+              .filter(eq("status", input.status)); // This is "active" from the input
+          }),
+      },
+    });
+
+    const repo = entityWithPreAppliedQueryFilters.createRepository(
+      mockTable as unknown as Table
+    );
+
+    const mockBuilder = {
+      filter: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue({ items: [] }),
+    };
+
+    mockTable.query.mockReturnValue(mockBuilder);
+
+    // Apply another filter when executing the query
+    await repo.query
+      .itemsByStatus({ status: "active", id: "123", test: "test" })
+      .filter(eq("type", "test"))
+      .execute();
+
+    expect(mockTable.query).toHaveBeenCalledWith({
+      pk: "TEST#123",
+    });
+
+    // Check that all filters are applied in the correct order:
+    // 1. Pre-applied filter from createQuery (status = "active")
+    // 2. Entity type filter (applied by query execution logic)
+    // 3. Execution-time filter (type = "test")
+    expect(mockBuilder.filter).toHaveBeenCalledTimes(3);
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(1, eq("status", "active"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(2, eq("entityType", "TestEntityWithQueryFilters"));
+    expect(mockBuilder.filter).toHaveBeenNthCalledWith(3, eq("type", "test"));
+  });
+});

--- a/src/builders/__tests__/query-builder.test.ts
+++ b/src/builders/__tests__/query-builder.test.ts
@@ -197,6 +197,341 @@ describe("QueryBuilder", () => {
 
     expect(result).toBe(builder);
   });
+
+  it("should chain two filters with AND", async () => {
+    const builder = new QueryBuilder(mockExecutor, mockKeyCondition);
+    builder
+      .filter((op) => op.eq("status", "active"))
+      .filter((op) => op.eq("type", "test"));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      mockKeyCondition,
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            { type: "eq", attr: "type", value: "test" },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should chain three filters with AND", async () => {
+    const builder = new QueryBuilder(mockExecutor, mockKeyCondition);
+    builder
+      .filter((op) => op.eq("status", "active"))
+      .filter((op) => op.eq("type", "test"))
+      .filter((op) => op.eq("name", "test"));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      mockKeyCondition,
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            { type: "eq", attr: "type", value: "test" },
+            { type: "eq", attr: "name", value: "test" },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should chain a mix of AND and OR filters", async () => {
+    const builder = new QueryBuilder(mockExecutor, mockKeyCondition);
+    builder
+      .filter((op) => op.eq("status", "active"))
+      .filter((op) => op.or(op.eq("type", "test"), op.eq("type", "test2")));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      mockKeyCondition,
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "type", value: "test" },
+                { type: "eq", attr: "type", value: "test2" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should handle complex nested filter combinations", async () => {
+    const builder = new QueryBuilder(mockExecutor, mockKeyCondition);
+    builder
+      .filter((op) => op.eq("status", "active"))
+      .filter((op) => op.or(op.eq("type", "test"), op.eq("type", "test2")))
+      .filter((op) => op.gt("createdAt", "2023-01-01"))
+      .filter((op) => op.and(op.lt("score", 100), op.ne("category", "deleted")));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      mockKeyCondition,
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "type", value: "test" },
+                { type: "eq", attr: "type", value: "test2" },
+              ],
+            },
+            { type: "gt", attr: "createdAt", value: "2023-01-01" },
+            {
+              type: "and",
+              conditions: [
+                { type: "lt", attr: "score", value: 100 },
+                { type: "ne", attr: "category", value: "deleted" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should handle filter chaining with existing AND condition", async () => {
+    const builder = new QueryBuilder(mockExecutor, mockKeyCondition);
+    
+    // First add a complex filter that creates an AND condition
+    builder.filter((op) => op.and(op.eq("status", "active"), op.eq("type", "test")));
+    
+    // Then add more filters that should be appended to the existing AND
+    builder.filter((op) => op.gt("createdAt", "2023-01-01"));
+    builder.filter((op) => op.lt("score", 100));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      mockKeyCondition,
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            { type: "eq", attr: "type", value: "test" },
+            { type: "gt", attr: "createdAt", value: "2023-01-01" },
+            { type: "lt", attr: "score", value: 100 },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should handle initial filter as single condition", async () => {
+    const builder = new QueryBuilder(mockExecutor, mockKeyCondition);
+    
+    // Add a single condition first
+    builder.filter((op) => op.eq("status", "active"));
+    
+    // Then add more filters
+    builder.filter((op) => op.eq("type", "test"));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      mockKeyCondition,
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            { type: "eq", attr: "type", value: "test" },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should chain OR conditions properly", async () => {
+    const builder = new QueryBuilder(mockExecutor, mockKeyCondition);
+    builder
+      .filter((op) => op.or(op.eq("status", "active"), op.eq("status", "pending")))
+      .filter((op) => op.or(op.eq("type", "test"), op.eq("type", "prod")));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      mockKeyCondition,
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "status", value: "active" },
+                { type: "eq", attr: "status", value: "pending" },
+              ],
+            },
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "type", value: "test" },
+                { type: "eq", attr: "type", value: "prod" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should chain multiple OR conditions with complex logic", async () => {
+    const builder = new QueryBuilder(mockExecutor, mockKeyCondition);
+    builder
+      .filter((op) => op.or(op.eq("status", "active"), op.eq("status", "pending")))
+      .filter((op) => op.eq("verified", true))
+      .filter((op) => op.or(
+        op.and(op.eq("type", "premium"), op.gt("score", 80)),
+        op.and(op.eq("type", "basic"), op.gt("score", 60))
+      ));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      mockKeyCondition,
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "status", value: "active" },
+                { type: "eq", attr: "status", value: "pending" },
+              ],
+            },
+            { type: "eq", attr: "verified", value: true },
+            {
+              type: "or",
+              conditions: [
+                {
+                  type: "and",
+                  conditions: [
+                    { type: "eq", attr: "type", value: "premium" },
+                    { type: "gt", attr: "score", value: 80 },
+                  ],
+                },
+                {
+                  type: "and",
+                  conditions: [
+                    { type: "eq", attr: "type", value: "basic" },
+                    { type: "gt", attr: "score", value: 60 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should handle OR as the first filter followed by AND conditions", async () => {
+    const builder = new QueryBuilder(mockExecutor, mockKeyCondition);
+    builder
+      .filter((op) => op.or(op.eq("category", "A"), op.eq("category", "B")))
+      .filter((op) => op.eq("active", true))
+      .filter((op) => op.gt("score", 50));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      mockKeyCondition,
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "category", value: "A" },
+                { type: "eq", attr: "category", value: "B" },
+              ],
+            },
+            { type: "eq", attr: "active", value: true },
+            { type: "gt", attr: "score", value: 50 },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should chain OR with existing OR condition", async () => {
+    const builder = new QueryBuilder(mockExecutor, mockKeyCondition);
+    
+    // Start with a complex OR condition
+    builder.filter((op) => op.or(
+      op.eq("status", "active"), 
+      op.eq("status", "pending"), 
+      op.eq("status", "review")
+    ));
+    
+    // Add another OR condition - should be wrapped in AND
+    builder.filter((op) => op.or(
+      op.eq("priority", "high"), 
+      op.eq("priority", "urgent")
+    ));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      mockKeyCondition,
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "status", value: "active" },
+                { type: "eq", attr: "status", value: "pending" },
+                { type: "eq", attr: "status", value: "review" },
+              ],
+            },
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "priority", value: "high" },
+                { type: "eq", attr: "priority", value: "urgent" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
 });
 
 //TODO test object equality

--- a/src/builders/__tests__/scan-builder.test.ts
+++ b/src/builders/__tests__/scan-builder.test.ts
@@ -151,6 +151,32 @@ describe("ScanBuilder", () => {
     expect(cloneCall).toEqual(originalCall);
   });
 
+  it("should maintain immutability when chaining filters after cloning", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    builder.filter((op) => op.eq("status", "active"));
+    
+    const clone = builder.clone();
+    
+    // Add different filters to each builder
+    builder.filter((op) => op.eq("type", "original"));
+    clone.filter((op) => op.eq("type", "cloned"));
+    
+    // Execute both and verify they have different filters
+    const originalResult = await builder.execute();
+    await originalResult.toArray(); // Consume the iterator to trigger executor call
+    const originalCall = mockExecutor.mock.calls[0]?.[0];
+    
+    mockExecutor.mockClear();
+    const cloneResult = await clone.execute();
+    await cloneResult.toArray(); // Consume the iterator to trigger executor call
+    const cloneCall = mockExecutor.mock.calls[0]?.[0];
+    
+    // Verify the filters are different (proving immutability)
+    expect(originalCall.filter?.conditions?.[1]?.value).toBe("original");
+    expect(cloneCall.filter?.conditions?.[1]?.value).toBe("cloned");
+    expect(originalCall).not.toEqual(cloneCall);
+  });
+
   it("should execute scan with correct parameters", async () => {
     const builder = new ScanBuilder(mockExecutor);
     builder.limit(10).useIndex("myIndex");

--- a/src/builders/__tests__/scan-builder.test.ts
+++ b/src/builders/__tests__/scan-builder.test.ts
@@ -227,4 +227,329 @@ describe("ScanBuilder", () => {
     expect(items).toEqual([{ id: "1" }]);
     expect(resultIterator.getLastEvaluatedKey()).toEqual(lastKey);
   });
+
+  it("should chain two filters with AND", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    builder
+      .filter((op) => op.eq("status", "active"))
+      .filter((op) => op.eq("type", "test"));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            { type: "eq", attr: "type", value: "test" },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should chain three filters with AND", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    builder
+      .filter((op) => op.eq("status", "active"))
+      .filter((op) => op.eq("type", "test"))
+      .filter((op) => op.eq("name", "test"));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            { type: "eq", attr: "type", value: "test" },
+            { type: "eq", attr: "name", value: "test" },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should chain a mix of AND and OR filters", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    builder
+      .filter((op) => op.eq("status", "active"))
+      .filter((op) => op.or(op.eq("type", "test"), op.eq("type", "test2")));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "type", value: "test" },
+                { type: "eq", attr: "type", value: "test2" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should handle complex nested filter combinations", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    builder
+      .filter((op) => op.eq("status", "active"))
+      .filter((op) => op.or(op.eq("type", "test"), op.eq("type", "test2")))
+      .filter((op) => op.gt("createdAt", "2023-01-01"))
+      .filter((op) => op.and(op.lt("score", 100), op.ne("category", "deleted")));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "type", value: "test" },
+                { type: "eq", attr: "type", value: "test2" },
+              ],
+            },
+            { type: "gt", attr: "createdAt", value: "2023-01-01" },
+            {
+              type: "and",
+              conditions: [
+                { type: "lt", attr: "score", value: 100 },
+                { type: "ne", attr: "category", value: "deleted" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should handle filter chaining with existing AND condition", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    
+    // First add a complex filter that creates an AND condition
+    builder.filter((op) => op.and(op.eq("status", "active"), op.eq("type", "test")));
+    
+    // Then add more filters that should be appended to the existing AND
+    builder.filter((op) => op.gt("createdAt", "2023-01-01"));
+    builder.filter((op) => op.lt("score", 100));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            { type: "eq", attr: "type", value: "test" },
+            { type: "gt", attr: "createdAt", value: "2023-01-01" },
+            { type: "lt", attr: "score", value: 100 },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should handle initial filter as single condition", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    
+    // Add a single condition first
+    builder.filter((op) => op.eq("status", "active"));
+    
+    // Then add more filters
+    builder.filter((op) => op.eq("type", "test"));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            { type: "eq", attr: "status", value: "active" },
+            { type: "eq", attr: "type", value: "test" },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should chain OR conditions properly", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    builder
+      .filter((op) => op.or(op.eq("status", "active"), op.eq("status", "pending")))
+      .filter((op) => op.or(op.eq("type", "test"), op.eq("type", "prod")));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "status", value: "active" },
+                { type: "eq", attr: "status", value: "pending" },
+              ],
+            },
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "type", value: "test" },
+                { type: "eq", attr: "type", value: "prod" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should chain multiple OR conditions with complex logic", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    builder
+      .filter((op) => op.or(op.eq("status", "active"), op.eq("status", "pending")))
+      .filter((op) => op.eq("verified", true))
+      .filter((op) => op.or(
+        op.and(op.eq("type", "premium"), op.gt("score", 80)),
+        op.and(op.eq("type", "basic"), op.gt("score", 60))
+      ));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "status", value: "active" },
+                { type: "eq", attr: "status", value: "pending" },
+              ],
+            },
+            { type: "eq", attr: "verified", value: true },
+            {
+              type: "or",
+              conditions: [
+                {
+                  type: "and",
+                  conditions: [
+                    { type: "eq", attr: "type", value: "premium" },
+                    { type: "gt", attr: "score", value: 80 },
+                  ],
+                },
+                {
+                  type: "and",
+                  conditions: [
+                    { type: "eq", attr: "type", value: "basic" },
+                    { type: "gt", attr: "score", value: 60 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should handle OR as the first filter followed by AND conditions", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    builder
+      .filter((op) => op.or(op.eq("category", "A"), op.eq("category", "B")))
+      .filter((op) => op.eq("active", true))
+      .filter((op) => op.gt("score", 50));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "category", value: "A" },
+                { type: "eq", attr: "category", value: "B" },
+              ],
+            },
+            { type: "eq", attr: "active", value: true },
+            { type: "gt", attr: "score", value: 50 },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("should chain OR with existing OR condition", async () => {
+    const builder = new ScanBuilder(mockExecutor);
+    
+    // Start with a complex OR condition
+    builder.filter((op) => op.or(
+      op.eq("status", "active"), 
+      op.eq("status", "pending"), 
+      op.eq("status", "review")
+    ));
+    
+    // Add another OR condition - should be wrapped in AND
+    builder.filter((op) => op.or(
+      op.eq("priority", "high"), 
+      op.eq("priority", "urgent")
+    ));
+
+    const resultIterator = await builder.execute();
+    await resultIterator.toArray(); // Consume the iterator to trigger executor call
+
+    expect(mockExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          type: "and",
+          conditions: [
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "status", value: "active" },
+                { type: "eq", attr: "status", value: "pending" },
+                { type: "eq", attr: "status", value: "review" },
+              ],
+            },
+            {
+              type: "or",
+              conditions: [
+                { type: "eq", attr: "priority", value: "high" },
+                { type: "eq", attr: "priority", value: "urgent" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
 });

--- a/src/builders/filter-builder.ts
+++ b/src/builders/filter-builder.ts
@@ -185,11 +185,14 @@ export abstract class FilterBuilder<T extends DynamoItem, TConfig extends TableC
     const newCondition = typeof condition === "function" ? condition(this.getConditionOperator()) : condition;
 
     if (this.options.filter) {
-      // If the existing filter is already an 'and' condition, we can just push the new
-      // condition to it. Otherwise, we need to create a new 'and' condition. This
-      // is to avoid nesting 'and' conditions, which is not ideal.
+      // If the existing filter is already an 'and' condition, create a new AND node
+      // with a new conditions array to avoid mutating the existing one (preserves immutability).
+      // Otherwise, we need to create a new 'and' condition. This avoids nesting 'and' conditions.
       if (this.options.filter.type === "and" && this.options.filter.conditions) {
-        this.options.filter.conditions.push(newCondition);
+        this.options.filter = {
+          type: "and",
+          conditions: [...this.options.filter.conditions, newCondition]
+        };
       } else {
         this.options.filter = and(this.options.filter, newCondition);
       }

--- a/src/builders/query-builder.ts
+++ b/src/builders/query-builder.ts
@@ -184,9 +184,23 @@ export class QueryBuilder<T extends DynamoItem, TConfig extends TableConfig = Ta
    */
   clone(): QueryBuilder<T, TConfig> {
     const clone = new QueryBuilder<T, TConfig>(this.executor, this.keyCondition);
-    clone.options = { ...this.options };
+    clone.options = { 
+      ...this.options,
+      filter: this.deepCloneFilter(this.options.filter)
+    };
     clone.selectedFields = new Set(this.selectedFields);
     return clone;
+  }
+
+  private deepCloneFilter(filter: Condition | undefined): Condition | undefined {
+    if (!filter) return filter;
+    if (filter.type === "and" || filter.type === "or") {
+      return {
+        ...filter,
+        conditions: filter.conditions?.map(condition => this.deepCloneFilter(condition)).filter((c): c is Condition => c !== undefined)
+      };
+    }
+    return { ...filter };
   }
 
   /**


### PR DESCRIPTION
The commit adds support for chaining multiple filters in entity queries and table operations. The chained filter calls are combined with AND logic. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added guidance and examples showing how chaining multiple filters combines them with AND, and how to apply conditional filters at definition vs runtime.

- Tests
  - Greatly expanded tests covering filter-chaining scenarios, nesting (AND/OR), and independence of query instances.

- Refactor
  - Made filter handling more predictable and ensured query instances don’t share filter state; improved index-update error messages for missing attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->